### PR TITLE
Fix KeyError: 'includepokhrel' and README example typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed the `--includepokherl` CLI option. This is a breaking change ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #10](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/10); [@brews](https://github.com/brews)).
-- Heavy internal refactoring to improve code clarity and testability ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #(9)](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/9); [@brews](https://github.com/brews)).
+- Heavy internal refactoring to improve code clarity and testability ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #9](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/9); [@brews](https://github.com/brews)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Removed the `--includepokherl` CLI option. This is a breaking change ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8); [@brews](https://github.com/brews)).
+- Removed the `--includepokherl` CLI option. This is a breaking change ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #10](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/10); [@brews](https://github.com/brews)).
 - Heavy internal refactoring to improve code clarity and testability ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #(9)](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/9); [@brews](https://github.com/brews)).
 
 ### Fixed
 
-- GWD files may not have been used when used with the `--includepokherl` option ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8); [@brews](https://github.com/brews)).
+- GWD files may not have been used when used with the `--includepokherl` option ([PR #8](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/8), [PR #10](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/10); [@brews](https://github.com/brews)).
+- Fix bad container name in README example ([PR #10](https://github.com/fact-sealevel/ssp-landwaterstorage/pull/10); [@brews](https://github.com/brews)).
 - Bad release hyperlinks in CHANGELOG.
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Now run the container, for example with Docker, like
 docker run --rm \
     -v ./data/input:/mnt/ssp_lws_in:ro \
     -v ./data/output:/mnt/ssp_lws_out \
-    ghcr.io/facts-sealevel/ssp-landwaterstorage:latest \
+    ghcr.io/fact-sealevel/ssp-landwaterstorage:latest \
     --pipeline-id=1234 \
     --output-gslr-file="/mnt/ssp_lws_out/output_gslr.nc" \
     --output-lslr-file="/mnt/ssp_lws_out/output_lslr.nc" \

--- a/src/ssp_landwaterstorage/core.py
+++ b/src/ssp_landwaterstorage/core.py
@@ -284,7 +284,6 @@ def fit(my_data, my_config, pipeline_id):
     yrs = my_config["yrs"]
     _ = my_config["scen"]
     dotriangular = my_config["dotriangular"]
-    includepokhrel = my_config["includepokhrel"]
 
     # interpolate reservoir years to population history years t0
     dams = np.interp(t0, tdams, dams)
@@ -304,7 +303,7 @@ def fit(my_data, my_config, pipeline_id):
     pop2gwd_all = []  # population
 
     # Loop over each of the GWD files' data
-    for i in np.arange(0, 2 + includepokhrel):
+    for i in np.arange(gwds.shape[0]):
         # Working with these particular data
         gwd = gwds[i, :]
         tgwd = tgwds[i, :]
@@ -433,7 +432,6 @@ def project(
     targyears = my_config["targyears"]
     scen = my_config["scen"]
     dotriangular = my_config["dotriangular"]
-    _ = my_config["includepokhrel"]
 
     # optimisation problem, least squares of fitting dams with sigmoidal function of population
     def sigmoidal(pop0, a, b, c, I0):


### PR DESCRIPTION
At the moment if users run this, they'll get an error similar to `KeyError: 'includepokhrel'`. This is leftover from PR #8 when we removed the `--includepokhrel` option, it looks like I didn't finish my fix there.

This PR fixes this error so things should run to completion using whatever GWD files get passed in via the `--gwd-file` option.

In addition, this PR fixes a typo in the README example. There was a bad image name in one of the commands.

CHANGELOG has been updated to reflect all these changes.